### PR TITLE
Update kube api resources

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,34 +1,58 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: podmon
   name: podmon
   namespace: kube-system
 spec:
+  progressDeadlineSeconds: 2147483647
   replicas: 1
+  revisionHistoryLimit: 2147483647
+  selector:
+    matchLabels:
+      app: podmon
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
-      labels:
-        app: podmon
       annotations:
         iam.amazonaws.com/role: kubernetes_podmon
+      creationTimestamp: null
+      labels:
+        app: podmon
     spec:
       containers:
-        - name: podmon
-          image: registry.usw.co/cloud/k8s-podmon:{{ .Env.DRONE_COMMIT }}
-          imagePullPolicy: Always
-          volumeMounts:
-            - mountPath: /etc/ssl/certs
-              name: ssl-certs-host
-              readOnly: true
-          args:
-            - -d
-          env:
-            - name: SLACK
-              valueFrom:
-                secretKeyRef:
-                  name: podmon
-                  key: slack
-      volumes:
-        - hostPath:
-            path: /usr/share/ca-certificates
+      - args:
+        - -d
+        env:
+        - name: SLACK
+          valueFrom:
+            secretKeyRef:
+              key: slack
+              name: podmon
+        image: registry.usw.co/cloud/k8s-podmon:{{ .Env.DRONE_COMMIT }}
+        imagePullPolicy: Always
+        name: podmon
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
           name: ssl-certs-host
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: ""
+        name: ssl-certs-host
+status: {}


### PR DESCRIPTION
Hello there,

In preparation for upgrading to Kubernetes v1.16, (note: we have recently upgraded to v1.13), we have made changes to some of your kubernetes manifests.

The v1.16 release will stop serving a number of deprecated API versions in favor of newer and more stable API versions. For us, this means DaemonSet, Deployment, StatefulSet, and ReplicaSet all need to be updated to be using apps/v1. 

Any manifests referencing deprecated APIs (extensions/v1beta1, apps/v1beta1, or apps/v1beta2) will need to be updated before we roll out Kubernetes v1.16 in order to continue to work.

To lessen the work, we have gone through all the repositories and updated the resource APIs for you. We have pushed any changes to the `machinegun-<randomstring>` branch so feel free to make any changes and/or updates to this branch.

Note: If you are making changes, specifically to Deployments, make sure that you leave the Selector field under the Spec section as this is now mandatory.

During the conversion process, resources may have been updated with defaults and/or changed API fields. The defaults that you see were already in use but are now explicitly set.

Cosmetic changes may have also occurred, for example API fields may have moved around and comments may have been removed. Feel free to move API fields back to their original positions and re-add comments.

We appreciate your assistance in ensuring a smooth transition to Kubernetes v1.16.

If you have any questions, message in #cloud-infrastructure.

Thanks,

Cloud Team